### PR TITLE
Regex fails announce URLs with a trailing slash.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,4 @@
-var URL = /^((http|udp|ftp)s?:\/\/)?([a-zA-Z1-90-]{2,}\.)+?([a-zA-Z1-90-]{2,6})(:\d{2,})?(\/\S+)*$/;
+var URL = /^((http|udp|ftp)s?:\/\/)?([a-zA-Z1-90-]{2,}\.)+?([a-zA-Z1-90-]{2,6})(:\d{2,})?(\S+)*$/;
 
 /**
  * Returns true if str is a URL


### PR DESCRIPTION
Previously failed for http://example.com/file.torrent/
