### PR TITLE
queue.process fix

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ module.exports = function(worker, concurrency) {
         process.nextTick(q.process);
       }
     , process: function() {
-        if (tasks.length) {
+        if (tasks.length > 0) {
           var task = tasks.shift();
           if (q.concurrency(workers, task.data)) {
             if (q.empty && tasks.length === 0) q.empty();
@@ -33,8 +33,9 @@ module.exports = function(worker, concurrency) {
               if (task.callback) task.callback.apply(task, arguments);
               if (q.drain && tasks.length + workers === 0) {
                 q.drain();
+              } else {
+                q.process();
               }
-              q.process();
             });
           } else {
             return tasks.unshift(task);


### PR DESCRIPTION
in some cases it's possible for the queue process method to get called more times than necessary, which results in a null exception. while ensuring that the process method only gets called as many times as needed is a more complicated matter, a simple check for tasks length should take care of the problem and extra calls to process method should do no harm. 
the problem is more apparent on windows but it can also be replicated on osx and ubuntu.  
