### PR TITLE
Only closing the filesystem handle if it exists

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -83,7 +83,9 @@ var readStream = exports.readStream = function(rs, callback) {
     try {
       decoder.decode(data);
     } catch (err) {
-      fs.close(rs.fd);
+      if(rs.hasOwnProperty('fd')) {
+        fs.close(rs.fd);      
+      }
       callback(err);
     }
   });


### PR DESCRIPTION
In the case of readURL, if the url doesn't point to a torrent file, the decoding will fail, but there's not actual fd to close, so an exception is thrown from the catch block of readStream.
