### PR TITLE
Implements decompression if a gzip/deflate encoded http response is sent.

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -2,6 +2,8 @@ var fs      = require('fs');
 var b       = require('bncode');
 var request = require('request');
 var _       = require('underscore');
+var zlib    = require('zlib');
+var stream  = require('stream');
 
 var schema  = require('./schema');
 var util    = require('./util');
@@ -50,7 +52,45 @@ var readURL = exports.readURL = function(uri, options, callback) {
   _.extend(reqOptions, options);
 
   var rs = request(reqOptions);
-  return readStream(rs, callback);
+
+  
+  /**
+   * We will create an intermediate stream, which converts any data we
+   * receive over the wire from `rs` is decoded (since it can be in
+   * compressed form).
+   */
+  var decompressedStream = new stream.PassThrough()
+
+  rs.on('response', function (response) {
+      /**
+       * As soon as we receive a HTTP response, we're going to do the
+       * switch-a-roo of our bencodedStream -- if our data is encoded
+       * using a compression algorithm we recognize, pipe the stream
+       * through Zlib, otherwise just pipe the raw data.
+       */
+      switch (response.headers['content-encoding']) {
+      case 'gzip':
+          rs.pipe(zlib.createGunzip()).pipe(decompressedStream)
+          break;
+
+      case 'deflate':
+          rs.pipe(zlib.createInflate()).pipe(decompressedStream)
+          break;
+
+      default:
+          /**
+           * Default scenario, pipe all the data (since it likely is
+           * just raw bencoded data anyway).
+           */
+          rs.pipe(decompressedStream);
+      }
+  });
+
+  /*
+   * Note how we pass the decompressedStream here, even though there isn't a producer
+   * on this stream yet. 
+   */
+  return readStream(decompressedStream, callback);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "underscore": "1.3.x",
     "memorystream": "0.2.x",
     "ordered-emitter": "0.1.x",
-    "streamspeed": "0.1.x"
+    "streamspeed": "0.1.x",
+    "zlib": "1.x"
   },
   "devDependencies": {
     "vows": "0.5.x",


### PR DESCRIPTION
NodeJS' request module is used a lot, but doesn't decompress the body if the data is sent in compressed form. Many people have to re-implement the decompression of their requests themselves.

I ran into this problem with node-torrent. The compressed data is received and sent through bncode.decode(), which fails since it cannot read compressed data.

Whether this fix should be in node-torrent or in Node.Request is open for discussion, but here is a patch that does this automatically in the nt.readURL() function.
